### PR TITLE
Properly delimit config directory and upstream file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,17 @@ before_install: rm Gemfile.lock || true
 script: bundle exec rake test
 rvm:
   - 1.9.3
+  - 2.0.0
 env:
-  matrix:
   - PUPPET_VERSION="~> 3.1.0"
   - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.4.0"
   - PUPPET_VERSION="~> 3.6"
   - PUPPET_VERSION="~> 3.7"
+matrix:
+  exclude:
+    - rvm: 2.0.0
+      env: PUPPET_VERSION="~> 3.1.0"
 # Only notify for failed builds.
 notifications:
   email:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,7 +38,7 @@ class updatemotd::config {
 
   if $preserve_upstream {
     $upstream_files     = $updatemotd::params::upstream_files
-    $upstream_files_abs = prefix($upstream_files, $config_dir)
+    $upstream_files_abs = prefix($upstream_files, "${config_dir}/")
 
     # Marking these as undef tells Puppet not to purge them, nor care about
     # whether they currently exist or what they contain.

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -107,7 +107,7 @@ describe 'updatemotd' do
       let(:params) {{ }}
 
       upstream_files.each do |upstream_file|
-        it { should_not contain_file(upstream_file) }
+        it { should contain_file(upstream_file).with_ensure(nil) }
       end
     end
 


### PR DESCRIPTION
This prevents the upstream files from being purged. Also pinned rspec-puppet to allow tests to pass.