### PR TITLE
Migrate from Modulefile to metadata.json

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,9 +1,0 @@
-name          'gdsoperations-updatemotd'
-version       '0.0.1'
-source        'https://github.com/gds-operations/puppet-updatemotd'
-author        'Government Digital Service'
-license       'MIT'
-summary       'Manage update-motd(5) on Ubuntu systems'
-project_page  'https://github.com/gds-operations/puppet-updatemotd'
-
-dependency 'puppetlabs/stdlib', '>= 3.2.0 <4.0.0'

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name":         "gdsoperations-updatemotd",
+  "version":      "0.0.1",
+  "author":       "Government Digital Service",
+  "license":      "MIT",
+  "summary":      "Manage update-motd(5) on Ubuntu systems",
+  "source":       "https://github.com/gds-operations/puppet-updatemotd",
+  "project_page": "https://github.com/gds-operations/puppet-updatemotd",
+  "issues_url":   "https://github.com/gds-operations/puppet-updatemotd/issues",
+  "tags":         ["motd"],
+  "operatingsystem_support": [
+    {
+    "operatingsystem": "Ubuntu",
+    "operatingsystemrelease": ["12.04", "14.04"]
+    }
+  ],
+  "dependencies": [
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 3.2.0 <5.0.0" }
+  ]
+}


### PR DESCRIPTION
Modulefile is deprecated and metadata.json is the more
fully featured replacement.