### PR TITLE
README specifies that you should use 'updatemotd' before updatemotd::…

### DIFF
--- a/spec/defines/script_spec.rb
+++ b/spec/defines/script_spec.rb
@@ -8,6 +8,9 @@ describe 'updatemotd::script' do
   let(:title) { 'giraffe' }
   let(:config_dir) { '/etc/update-motd.d' }
   let(:config_file) { "#{config_dir}/50-giraffe" }
+  let(:pre_condition) {
+    'include updatemotd'
+  }
 
   describe 'order' do
     context 'valid values' do


### PR DESCRIPTION
…script

This changes makes the spec behave in the same way as the documentation claims